### PR TITLE
Fix compilation with GHC 9

### DIFF
--- a/library/Neovim/User/Input.hs
+++ b/library/Neovim/User/Input.hs
@@ -27,7 +27,7 @@ input :: NvimObject result
       -> Maybe String -- ^ Completion mode
       -> Neovim env result
 input message mPrefilled mCompletion = fmap fromObjectUnsafe
-  . vim_call_function "input" $ (message <> " ")
+  $ vim_call_function "input" $ (message <> " ")
     +: maybe "" id mPrefilled
     +: maybe [] (+: []) mCompletion
 
@@ -41,7 +41,7 @@ askForDirectory :: String -- ^ Message to put in front
 askForDirectory message mPrefilled = do
     fp <- input message mPrefilled (Just "dir")
 
-    efp <- fmap fromObjectUnsafe . vim_call_function "expand" $ (fp :: FilePath) +: []
+    efp <- fmap fromObjectUnsafe $ vim_call_function "expand" $ (fp :: FilePath) +: []
 
     whenM (not <$> liftIO (doesDirectoryExist efp)) $
         whenM (yesOrNo (efp ++ " does not exist, create it?")) $


### PR DESCRIPTION
With GHC 9, function compositions of forall'd functions fails with an
obscure error:

    library/Neovim/User/Input.hs:44:36: error:
        • Couldn't match type: forall env1. Neovim env1 Object
                         with: Neovim env Object
          Expected: [Object] -> Neovim env Object
            Actual: [Object] -> forall env. Neovim env Object
        • In the second argument of ‘(.)’, namely
            ‘vim_call_function "expand"’
          In the first argument of ‘($)’, namely
            ‘fmap fromObjectUnsafe . vim_call_function "expand"’
          In a stmt of a 'do' block:
            efp <- fmap fromObjectUnsafe . vim_call_function "expand"
                     $ (fp :: FilePath) +: []
        • Relevant bindings include
            askForDirectory :: String -> Maybe FilePath -> Neovim env FilePath
              (bound at library/Neovim/User/Input.hs:41:1)
       |
    44 |     efp <- fmap fromObjectUnsafe . vim_call_function "expand" $ (fp :: FilePath) +: []
       |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^

This seems to be related to [1], and can easily be fixed by replacing
the composition with an explicit function application.

[1] https://stackoverflow.com/q/43943793